### PR TITLE
Add psutil-based SystemStats widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # termyte
 Handheld computer terminal
+
+## Dependencies
+
+- [psutil](https://pypi.org/project/psutil/) – Used by the `SystemStats` widget to
+  gather CPU, memory, and network information.

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from typing import Dict
 
 from textual.app import App, ComposeResult
 from textual.widgets import Placeholder
+from widgets.system_stats import SystemStats
 
 
 @dataclass
@@ -59,7 +60,10 @@ class TermyteApp(App):
         """Compose layout, adding widgets only when enabled."""
         for name, cfg in self.widget_config.items():
             if cfg.enabled:
-                yield Placeholder(id=name)
+                if name == "system_stats":
+                    yield SystemStats()
+                else:
+                    yield Placeholder(id=name)
 
 
 def run() -> None:

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,0 +1,1 @@
+"""Widget implementations for Termyte."""

--- a/widgets/system_stats.py
+++ b/widgets/system_stats.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""System statistics widget using psutil."""
+
+import psutil
+from textual.widgets import TextLog
+
+
+class SystemStats(TextLog):
+    """A widget that displays real time CPU, memory and network stats."""
+
+    def on_mount(self) -> None:
+        """Set up a timer to refresh statistics."""
+        self.update_stats()
+        # Refresh every second
+        self.set_interval(1.0, self.update_stats)
+
+    def update_stats(self) -> None:
+        """Gather system statistics and write them to the log."""
+        cpu = psutil.cpu_percent()
+        mem = psutil.virtual_memory().percent
+        net = psutil.net_io_counters()
+
+        # Clear previous stats and write new ones
+        self.clear()
+        self.write(f"CPU Usage: {cpu}%")
+        self.write(f"Memory Usage: {mem}%")
+        self.write(f"Bytes Sent: {net.bytes_sent}")
+        self.write(f"Bytes Received: {net.bytes_recv}")


### PR DESCRIPTION
## Summary
- Add SystemStats widget to display CPU, memory, and network stats via psutil
- Instantiate SystemStats in app when enabled
- Document psutil dependency in README

## Testing
- `python -m py_compile app.py widgets/system_stats.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a75f9273f48329823a88e458374587