### PR TITLE
Add WebFeeds widget for RSS/Atom headlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ Handheld computer terminal
 
 - [psutil](https://pypi.org/project/psutil/) – Used by the `SystemStats` widget to
   gather CPU, memory, and network information.
+- [httpx](https://www.python-httpx.org/) – Fetches RSS/Atom feeds for the
+  `WebFeeds` widget.
+- [feedparser](https://pypi.org/project/feedparser/) – Parses feed data.
+- [PyYAML](https://pypi.org/project/PyYAML/) – Reads feed URLs from the
+  `feeds.yml` configuration file.
+
+## Web feed configuration
+
+The `WebFeeds` widget loads its feed URLs from a `feeds.yml` file in the project
+root.  The file should contain a list of feed URLs:
+
+```yaml
+feeds:
+  - https://hnrss.org/frontpage
+  - https://planetpython.org/rss20.xml
+```
+
+Each feed's headlines are rendered in a scrollable list.  With a headline
+highlighted, press `o` to open the article using the command specified in the
+`$BROWSER` environment variable (falling back to `xdg-open`).

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from typing import Dict
 from textual.app import App, ComposeResult
 from textual.widgets import Placeholder
 from widgets.system_stats import SystemStats
+from widgets.web_feeds import WebFeeds
 
 
 @dataclass
@@ -62,6 +63,8 @@ class TermyteApp(App):
             if cfg.enabled:
                 if name == "system_stats":
                     yield SystemStats()
+                elif name == "web_feeds":
+                    yield WebFeeds()
                 else:
                     yield Placeholder(id=name)
 

--- a/feeds.yml
+++ b/feeds.yml
@@ -1,0 +1,3 @@
+feeds:
+  - https://hnrss.org/frontpage
+  - https://planetpython.org/rss20.xml

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,1 +1,6 @@
 """Widget implementations for Termyte."""
+
+from .system_stats import SystemStats
+from .web_feeds import WebFeeds
+
+__all__ = ["SystemStats", "WebFeeds"]

--- a/widgets/web_feeds.py
+++ b/widgets/web_feeds.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Widget for displaying headlines from RSS/Atom feeds."""
+
+import asyncio
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+import feedparser
+import httpx
+import yaml
+from textual.widgets import Label, ListItem, ListView
+
+
+class FeedListItem(ListItem):
+    """List item storing a link to an article."""
+
+    def __init__(self, title: str, link: str) -> None:
+        super().__init__(Label(title))
+        self.link = link
+
+
+class WebFeeds(ListView):
+    """Scrollable list view that displays headlines from web feeds."""
+
+    BINDINGS = [
+        ("o", "open_link", "Open link in $BROWSER"),
+    ]
+
+    _CONFIG_LOCATIONS = [
+        Path(__file__).resolve().parent.parent / "feeds.yml",
+        Path(__file__).resolve().parent.parent / "feeds.yaml",
+        Path(__file__).resolve().parent.parent / "feeds.json",
+    ]
+
+    async def on_mount(self) -> None:
+        """Load configuration and fetch initial feed items."""
+        self.feed_urls = self._load_config()
+        await self.refresh_feeds()
+        # Refresh every 15 minutes
+        self.set_interval(900, self.refresh_feeds)
+
+    def _load_config(self) -> List[str]:
+        """Load feed URLs from YAML or JSON configuration file."""
+        for path in self._CONFIG_LOCATIONS:
+            if path.exists():
+                with path.open("r", encoding="utf-8") as config_file:
+                    if path.suffix == ".json":
+                        data = json.load(config_file)
+                    else:
+                        data = yaml.safe_load(config_file)
+                feeds = data.get("feeds", [])
+                return feeds if isinstance(feeds, list) else []
+        return []
+
+    async def refresh_feeds(self) -> None:
+        """Fetch and display feed headlines."""
+        self.clear()
+        if not self.feed_urls:
+            self.append(FeedListItem("No feeds configured", ""))
+            return
+
+        async with httpx.AsyncClient() as client:
+            tasks = [client.get(url, timeout=10.0) for url in self.feed_urls]
+            responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+        entries: List[Tuple[str, str]] = []
+        for response in responses:
+            if isinstance(response, Exception):
+                continue
+            parsed = feedparser.parse(response.text)
+            for entry in parsed.entries:
+                title = getattr(entry, "title", "Untitled")
+                link = getattr(entry, "link", "")
+                entries.append((title, link))
+
+        for title, link in entries:
+            self.append(FeedListItem(title, link))
+
+    def action_open_link(self) -> None:
+        """Open the highlighted feed link in the user's browser."""
+        item = self.highlighted_child
+        if item and getattr(item, "link", None):
+            browser = os.environ.get("BROWSER", "xdg-open")
+            subprocess.Popen([browser, item.link])


### PR DESCRIPTION
## Summary
- implement `WebFeeds` widget to fetch RSS/Atom feeds and display headlines in a scrollable list
- add key binding to open highlighted item in `$BROWSER`
- load feed URLs from configurable `feeds.yml`

## Testing
- `python -m py_compile widgets/web_feeds.py widgets/__init__.py app.py`
- `python - <<'PY'
import importlib.util, pathlib
spec = importlib.util.spec_from_file_location('web_feeds', pathlib.Path('widgets/web_feeds.py'))
web_feeds = importlib.util.module_from_spec(spec)
spec.loader.exec_module(web_feeds)
wf = web_feeds.WebFeeds()
print('config feeds:', wf._load_config())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a762add264832985859689186f2588