### PR TITLE
Add ShellWidget with PTY fallback and security notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ feeds:
 Each feed's headlines are rendered in a scrollable list.  With a headline
 highlighted, press `o` to open the article using the command specified in the
 `$BROWSER` environment variable (falling back to `xdg-open`).
+
+## Security notes
+
+The `ShellWidget` spawns an interactive shell inside the application. Anything
+typed into this widget runs with the same permissions as the user launching
+Termyte, so the program should only be used in trusted environments.
+

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from textual.app import App, ComposeResult
 from textual.widgets import Placeholder
 from widgets.system_stats import SystemStats
 from widgets.web_feeds import WebFeeds
+from widgets.shell import ShellWidget
 
 
 @dataclass
@@ -65,6 +66,8 @@ class TermyteApp(App):
                     yield SystemStats()
                 elif name == "web_feeds":
                     yield WebFeeds()
+                elif name == "shell":
+                    yield ShellWidget()
                 else:
                     yield Placeholder(id=name)
 

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,6 +1,7 @@
 """Widget implementations for Termyte."""
 
+from .shell import ShellWidget
 from .system_stats import SystemStats
 from .web_feeds import WebFeeds
 
-__all__ = ["SystemStats", "WebFeeds"]
+__all__ = ["SystemStats", "WebFeeds", "ShellWidget"]

--- a/widgets/shell.py
+++ b/widgets/shell.py
@@ -1,0 +1,93 @@
+"""Shell widget for Termyte.
+
+Attempts to use :class:`textual.widgets.Terminal` when available.  If the
+Terminal widget is missing, a minimal PTY based implementation is provided as a
+fallback.  The shell command launched defaults to ``/bin/bash`` but respects the
+``$SHELL`` environment variable when set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import pty
+from typing import Optional
+
+from rich.text import Text
+from textual import events
+from textual.widget import Widget
+
+try:  # pragma: no cover - optional dependency
+    from textual.widgets import Terminal as _Terminal
+except Exception:  # Terminal widget not available
+    _Terminal = None
+
+
+if _Terminal is not None:
+    class ShellWidget(_Terminal):
+        """Shell widget built upon Textual's Terminal widget."""
+
+        def __init__(self, shell: Optional[str] = None, **kwargs) -> None:
+            super().__init__(shell or os.environ.get("SHELL", "/bin/bash"), **kwargs)
+else:
+    class ShellWidget(Widget):
+        """Simple PTY-based shell widget.
+
+        Spawns an interactive shell inside a pseudo-terminal and relays user
+        input / output.  ANSI escape sequences are preserved so that shell
+        colors fit the application's retro theme.
+        """
+
+        DEFAULT_CSS = """
+        ShellWidget {
+            background: black;
+            color: #00ff00;
+        }
+        """
+
+        def __init__(self, shell: Optional[str] = None, **kwargs) -> None:
+            super().__init__(**kwargs)
+            self.shell = shell or os.environ.get("SHELL", "/bin/bash")
+            self._fd: Optional[int] = None
+            self._buffer = Text()
+            self._reader: Optional[asyncio.Task] = None
+
+        async def on_mount(self) -> None:
+            """Spawn the shell process when the widget is mounted."""
+            pid, fd = pty.fork()
+            if pid == 0:  # child process
+                os.execvp(self.shell, [self.shell])
+            self._fd = fd
+            os.set_blocking(fd, False)
+            self._reader = asyncio.create_task(self._read_pty())
+
+        async def _read_pty(self) -> None:
+            assert self._fd is not None
+            while True:
+                try:
+                    data = os.read(self._fd, 1024)
+                except BlockingIOError:
+                    await asyncio.sleep(0.05)
+                    continue
+                if not data:
+                    break
+                self._buffer += Text.from_ansi(data.decode("utf-8", "ignore"))
+                self.refresh()
+
+        def render(self) -> Text:
+            return self._buffer
+
+        async def on_key(self, event: events.Key) -> None:  # pragma: no cover - runtime
+            if self._fd is None:
+                return
+            key = event.key
+            if key == "enter":
+                os.write(self._fd, b"\n")
+            elif key == "tab":
+                os.write(self._fd, b"\t")
+            elif key == "backspace":
+                os.write(self._fd, b"\x7f")
+            elif key == "ctrl+c":
+                os.write(self._fd, b"\x03")
+            elif len(key) == 1:
+                os.write(self._fd, key.encode())


### PR DESCRIPTION
## Summary
- add ShellWidget, using Textual Terminal when present and PTY fallback otherwise
- wire ShellWidget into the application
- document security considerations for shell usage

## Testing
- `python -m py_compile app.py widgets/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a763f4ec6083299b02d84927896fc5