### PR TITLE
Add installation scripts and requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Termyte
 Handheld computer terminal
 
+## Installation
+
+Create a virtual environment and install the project's Python dependencies with
+the provided script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/<username>/termyte/main/scripts/install.sh | bash
+# or
+./scripts/install.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+./scripts/install.ps1
+```
+
 ## Dependencies
 
 - [psutil](https://pypi.org/project/psutil/) – Used by the `SystemStats` widget to

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+psutil
+httpx
+feedparser
+PyYAML
+evdev

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = 'Stop'
+$projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path | Split-Path -Parent
+$venvPath = Join-Path $projectRoot '.venv'
+
+if (-not (Test-Path $venvPath)) {
+    python -m venv $venvPath
+}
+
+& (Join-Path $venvPath 'Scripts/pip.exe') install -r (Join-Path $projectRoot 'requirements.txt')
+
+Write-Host "Virtual environment created at $venvPath"
+Write-Host "Activate with: `"$venvPath\Scripts\Activate.ps1`""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine project root
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$PROJECT_ROOT/.venv"
+
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
+fi
+
+"$VENV_DIR/bin/pip" install -r "$PROJECT_ROOT/requirements.txt"
+
+echo "Virtual environment created at $VENV_DIR"
+echo "Activate with: source $VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- add requirements.txt for core dependencies
- provide installation scripts for Unix and Windows
- document installation instructions in README

## Testing
- `bash scripts/install.sh`
- `.venv/bin/python -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a77fca29a48329b45057f5257ba5d8