### PR TITLE
Add rich and textual dependencies and limit evdev to Linux

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ psutil
 httpx
 feedparser
 PyYAML
-evdev
+rich
+textual
+evdev; platform_system == "Linux"


### PR DESCRIPTION
## Summary
- add `rich` and `textual` dependencies
- restrict `evdev` installation to Linux via environment marker

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a784724af483298ab93ca3d460a6ad