### PR TITLE
Improve install scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,4 +1,17 @@
 $ErrorActionPreference = 'Stop'
+
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Error 'python is not installed.'
+    exit 1
+}
+
+try {
+    python -m pip --version | Out-Null
+} catch {
+    Write-Error 'pip is not installed.'
+    exit 1
+}
+
 $projectRoot = Split-Path -Parent $MyInvocation.MyCommand.Path | Split-Path -Parent
 $venvPath = Join-Path $projectRoot '.venv'
 
@@ -6,7 +19,18 @@ if (-not (Test-Path $venvPath)) {
     python -m venv $venvPath
 }
 
-& (Join-Path $venvPath 'Scripts/pip.exe') install -r (Join-Path $projectRoot 'requirements.txt')
+$venvPython = Join-Path $venvPath 'Scripts/python.exe'
+& $venvPython -m pip install --upgrade pip
+
+$requirements = Join-Path $projectRoot 'requirements.txt'
+if ($IsLinux) {
+    & $venvPython -m pip install -r $requirements
+} else {
+    $tmp = New-TemporaryFile
+    Get-Content $requirements | Where-Object { $_ -notmatch '^evdev' } | Set-Content $tmp
+    & $venvPython -m pip install -r $tmp
+    Remove-Item $tmp
+}
 
 Write-Host "Virtual environment created at $venvPath"
 Write-Host "Activate with: `"$venvPath\Scripts\Activate.ps1`""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if ! command -v python >/dev/null 2>&1; then
+    echo "Error: python is not installed." >&2
+    exit 1
+fi
+
+if ! command -v pip >/dev/null 2>&1; then
+    echo "Error: pip is not installed." >&2
+    exit 1
+fi
+
 # Determine project root
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENV_DIR="$PROJECT_ROOT/.venv"
 
 if [ ! -d "$VENV_DIR" ]; then
-    python3 -m venv "$VENV_DIR"
+    python -m venv "$VENV_DIR"
 fi
 
-"$VENV_DIR/bin/pip" install -r "$PROJECT_ROOT/requirements.txt"
+"$VENV_DIR/bin/python" -m pip install --upgrade pip
+
+REQ_FILE="$PROJECT_ROOT/requirements.txt"
+if [ "$(uname)" != "Linux" ]; then
+    TMP_REQ="$(mktemp)"
+    grep -v '^evdev' "$REQ_FILE" > "$TMP_REQ"
+    REQ_FILE="$TMP_REQ"
+fi
+
+"$VENV_DIR/bin/python" -m pip install -r "$REQ_FILE"
+
+if [ -n "${TMP_REQ:-}" ]; then
+    rm -f "$TMP_REQ"
+fi
 
 echo "Virtual environment created at $VENV_DIR"
 echo "Activate with: source $VENV_DIR/bin/activate"


### PR DESCRIPTION
## Summary
- ensure `python` and `pip` are available before proceeding
- upgrade pip inside the venv and install requirements via `python -m pip`
- skip installing `evdev` on non-Linux systems

## Testing
- `bash -n scripts/install.sh`
- `pwsh -NoProfile -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78dacdfbc8329bf98025e9509c77a