### PR TITLE
Update system stats widget for new Textual API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ httpx
 feedparser
 PyYAML
 rich
-textual
+textual>=0.47
 evdev; platform_system == "Linux"

--- a/widgets/system_stats.py
+++ b/widgets/system_stats.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 """System statistics widget using psutil."""
 
 import psutil
-from textual.widgets import TextLog
+from textual.widgets import Log
 
 
-class SystemStats(TextLog):
+class SystemStats(Log):
     """A widget that displays real time CPU, memory and network stats."""
 
     def on_mount(self) -> None:
@@ -21,9 +21,14 @@ class SystemStats(TextLog):
         mem = psutil.virtual_memory().percent
         net = psutil.net_io_counters()
 
-        # Clear previous stats and write new ones
+        # Clear previous stats and log new ones
         self.clear()
-        self.write(f"CPU Usage: {cpu}%")
-        self.write(f"Memory Usage: {mem}%")
-        self.write(f"Bytes Sent: {net.bytes_sent}")
-        self.write(f"Bytes Received: {net.bytes_recv}")
+        self.log(f"CPU Usage: {cpu}%")
+        self.log(f"Memory Usage: {mem}%")
+        self.log(f"Bytes Sent: {net.bytes_sent}")
+        self.log(f"Bytes Received: {net.bytes_recv}")
+
+    # Compatibility wrapper for Textual's Log widget
+    def log(self, message: str) -> None:  # type: ignore[override]
+        """Write a message to the log widget."""
+        super().write(message)


### PR DESCRIPTION
## Summary
- Switch SystemStats widget to Textual's `Log` and adapt log calls
- Pin Textual dependency to versions with `Log` widget

## Testing
- `python -m py_compile widgets/system_stats.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7a88ce2f48329b9a3bfb9e816d6d1